### PR TITLE
Remove template boilerplate in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,5 @@
 # niveristand-custom-device-wizard
 
-niveristand-custom-device-wizard is a template for creation of open source projects made
-available on GitHub. It includes a permissive open source license, a developer
-certificate of origin, and a pull request template. This provides everything
-necessary to have a properly licensed open source project.
-
-## Using niveristand-custom-device-wizard
-
-1. Clone or download this repository.
-2. Copy its contents into your project (including the hidden .github directory). 
-3. Customize each file to suit your project's needs (including the README). Look through the files for "TODO" and niveristand-custom-device-wizard, and replace with content appropriate to your project.
-4. (Optional) Check out [GitHub Template Guidelines](https://github.com/cezaraugusto/github-template-guidelines) for ideas about how to customize your project.
-
 This project template is a consolidated version of pre-existing project templates for creating custom devices. It includes the following templates:
 
 - Asynchronous
@@ -22,3 +10,7 @@ This project template is a consolidated version of pre-existing project template
 - Asynchronous Timing and Sync
 
 The scripting code uses a LV Class-based design that allows you to easily add support for creating new custom device project templates.
+
+## Using niveristand-custom-device-wizard
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for usage instructions.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-wizard/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the README to point to CONTRIBUTING.md, remove template boilerplate.

### Why should this Pull Request be merged?

The existing README isn't very useful.

### What testing has been done?

N/A
