### PR TITLE
Add LV 2020, drop LV 2016

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-List<String> lvVersions = ['2016', '2017', '2018', '2019']
+List<String> lvVersions = ['2017', '2018', '2019', '2020']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions)
 diffPipeline(lvVersions[0])


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-wizard/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Builds the wizard for LV 2017-2020. Drops support for LV 2016.

### Why should this Pull Request be merged?

The build is failing because we have no build nodes with LV 2016 anymore, as that version will not be supported with the latest release.

### What testing has been done?

None. Waiting on build.
