### PR TITLE
Enable notifications and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add names of code owners for this repo
-* @niphilj @buckd
+* @buckd @rtzoeller

--- a/build.toml
+++ b/build.toml
@@ -9,3 +9,6 @@ path = 'ProjectTemplate\Source\NI VeriStand\Custom Device\Null.lvproj'
 type = 'nipkg'
 payload_dir = 'ProjectTemplate'
 install_destination = 'ni-paths-LV{labview_version}DIR\ProjectTemplates'
+
+[notification]
+type = 'teams'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables build notifications to MS Teams
Updates codeowners

### Why should this Pull Request be merged?

Build failures will send notifications and codeowners have changed.

### What testing has been done?

None
