### PR TITLE
Build for 64-bit LabVIEW

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-List<String> lvVersions = ['2017', '2018', '2019', '2020']
+def lvVersions = [
+  32 : ['2019', '2020'],
+  64 : ['2021']
+]
 
+diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)
-diffPipeline(lvVersions[0])

--- a/build.toml
+++ b/build.toml
@@ -8,7 +8,7 @@ path = 'ProjectTemplate\Source\NI VeriStand\Custom Device\Null.lvproj'
 [package]
 type = 'nipkg'
 payload_dir = 'ProjectTemplate'
-install_destination = 'ni-paths-LV{labview_version}DIR\ProjectTemplates'
+install_destination = 'ni-paths-LV{labview_version}DIR{nipaths_64_bitness_suffix}\ProjectTemplates'
 
 [notification]
 type = 'teams'

--- a/control
+++ b/control
@@ -12,3 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: VeriStand Custom Device Wizard for LabVIEW {labview_version}
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-wizard/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes #33 
Drops LabVIEW 2017 and 2018 support.
Adds LabVIEW 2021 support.

### Why should this Pull Request be merged?

Beginning with VeriStand 2021, custom devices will need to be built with LabVIEW 64-bit, so we need the wizard to generate projects in LabVIEW 64-bit.

### What testing has been done?

Waiting on PR build.
