### PR TITLE
Mark architecture as windows_x64

### DIFF
--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: ni-custom-device-wizard-labview-{labview_version}-support
 Version: {nipkg_version}
-Architecture: windows_all
+Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
 Description: Provides VeriStand custom device wizard for LabVIEW {labview_version}.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-wizard/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Mark architecture as windows_x64 in control file

### Why should this Pull Request be merged?

Package is failing to install on Win10 64-bit with LabVIEW 2021 SP1 and VeriStand 2021 installed
![image](https://user-images.githubusercontent.com/31290917/154578546-fcec0f22-e333-4052-818e-99668adc7af6.png)

### What testing has been done?

Tested installing the packages from the PR build on VMs with both VS 2020 and VS 2021 software stacks